### PR TITLE
Bugfix/n3 format

### DIFF
--- a/test/surface/concurrency.test.ts
+++ b/test/surface/concurrency.test.ts
@@ -164,8 +164,8 @@ if (process.env.SKIP_CONC) {
               "Content-Type": "text/n3",
             },
             body:
-                "@prefix solid: <http://www.w3.org/ns/solid/terms#>." +
-                "#patch a solid:InsertDeletePatch;" +
+                "@prefix solid: <http://www.w3.org/ns/solid/terms#>.\n" +
+                "<#patch> a solid:InsertDeletePatch;\n" +
                 `  solid:inserts { ${triple} .}.`,
           });
           expectedRdf += `${triple}\n`;

--- a/test/surface/create-non-container.test.ts
+++ b/test/surface/create-non-container.test.ts
@@ -195,8 +195,8 @@ describe("Create non-container", () => {
             "Content-Type": "text/n3",
           },
           body:
-            "@prefix solid: <http://www.w3.org/ns/solid/terms#>." +
-            "#patch a solid:InsertDeletePatch;" +
+            "@prefix solid: <http://www.w3.org/ns/solid/terms#>.\n" +
+            "<#patch> a solid:InsertDeletePatch;\n" +
             "  solid:inserts { <#hello> <#linked> <#world> .}.",
         });
         //		console.log(result);
@@ -357,8 +357,8 @@ describe("Create non-container", () => {
             "Content-Type": "text/n3",
           },
           body:
-            "@prefix solid: <http://www.w3.org/ns/solid/terms#>." +
-            "#patch a solid:InsertDeletePatch;" +
+            "@prefix solid: <http://www.w3.org/ns/solid/terms#>.\n" +
+            "<#patch> a solid:InsertDeletePatch;\n" +
             "  solid:inserts { <#hello> <#linked> <#world> .}.",
         });
         await new Promise((resolve) => setTimeout(resolve, 2000));

--- a/test/surface/update.test.ts
+++ b/test/surface/update.test.ts
@@ -251,8 +251,8 @@ describe("Update", () => {
           "Content-Type": "text/n3",
         },
         body:
-          "@prefix solid: <http://www.w3.org/ns/solid/terms#>." +
-          "#patch a solid:InsertDeletePatch;" +
+          "@prefix solid: <http://www.w3.org/ns/solid/terms#>.\n" +
+          "<#patch> a solid:InsertDeletePatch;\n" +
           "  solid:inserts { <#that> a <#fact> . }.",
       });
       await new Promise((resolve) => setTimeout(resolve, waittime));
@@ -316,8 +316,8 @@ describe("Update", () => {
           "Content-Type": "text/n3",
         },
         body:
-          "@prefix solid: <http://www.w3.org/ns/solid/terms#>." +
-          "#patch a solid:InsertDeletePatch;" +
+          "@prefix solid: <http://www.w3.org/ns/solid/terms#>.\n" +
+          "<#patch> a solid:InsertDeletePatch;\n" +
           "  solid:deletes { <#hello> <#linked> <#world> .}." +
           "  solid:inserts { <#hello> <#linked> <#world> .}.",
       });
@@ -382,8 +382,8 @@ describe("Update", () => {
           "Content-Type": "text/n3",
         },
         body:
-          "@prefix solid: <http://www.w3.org/ns/solid/terms#>." +
-          "#patch a solid:InsertDeletePatch;" +
+          "@prefix solid: <http://www.w3.org/ns/solid/terms#>.\n" +
+          "<#patch> a solid:InsertDeletePatch;\n" +
           "  solid:deletes { <#hello> <#linked> <#world> .}." +
           "  solid:inserts { <#that> a <#fact> .}.",
       });
@@ -448,8 +448,8 @@ describe("Update", () => {
           "Content-Type": "text/n3",
         },
         body:
-          "@prefix solid: <http://www.w3.org/ns/solid/terms#>." +
-          "#patch a solid:InsertDeletePatch;" +
+          "@prefix solid: <http://www.w3.org/ns/solid/terms#>.\n" +
+          "<#patch> a solid:InsertDeletePatch;\n" +
           "  solid:deletes { <#something> <#completely> <#different> .}." +
           "  solid:inserts { <#that> a <#fact> .}.",
       });
@@ -516,8 +516,8 @@ describe("Update", () => {
           "Content-Type": "text/n3",
         },
         body:
-          "@prefix solid: <http://www.w3.org/ns/solid/terms#>." +
-          "#patch a solid:InsertDeletePatch;" +
+          "@prefix solid: <http://www.w3.org/ns/solid/terms#>.\n" +
+          "<#patch> a solid:InsertDeletePatch;\n" +
           "  solid:deletes { <#hello> <#linked> <#world> .}.",
       });
     });
@@ -573,8 +573,8 @@ describe("Update", () => {
           "Content-Type": "text/n3",
         },
         body:
-          "@prefix solid: <http://www.w3.org/ns/solid/terms#>." +
-          "#patch a solid:InsertDeletePatch;" +
+          "@prefix solid: <http://www.w3.org/ns/solid/terms#>.\n" +
+          "<#patch> a solid:InsertDeletePatch;\n" +
           "  solid:deletes { <#something> <#completely> <#different> .}.",
       });
     });

--- a/test/surface/update.test.ts
+++ b/test/surface/update.test.ts
@@ -38,6 +38,7 @@ describe("Update", () => {
     }
     authFetcher = await getAuthFetcher(oidcIssuer, newCookie, appOrigin);
   });
+
   describe("Using PUT, overwriting plain text with plain text", () => {
     const { testFolderUrl } = generateTestFolder();
     let websocketsPubsubClientResource;
@@ -318,7 +319,7 @@ describe("Update", () => {
         body:
           "@prefix solid: <http://www.w3.org/ns/solid/terms#>.\n" +
           "<#patch> a solid:InsertDeletePatch;\n" +
-          "  solid:deletes { <#hello> <#linked> <#world> .}." +
+          "  solid:deletes { <#hello> <#linked> <#world> .};\n" +
           "  solid:inserts { <#hello> <#linked> <#world> .}.",
       });
       await new Promise((resolve) => setTimeout(resolve, waittime));
@@ -384,7 +385,7 @@ describe("Update", () => {
         body:
           "@prefix solid: <http://www.w3.org/ns/solid/terms#>.\n" +
           "<#patch> a solid:InsertDeletePatch;\n" +
-          "  solid:deletes { <#hello> <#linked> <#world> .}." +
+          "  solid:deletes { <#hello> <#linked> <#world> .};\n" +
           "  solid:inserts { <#that> a <#fact> .}.",
       });
       await new Promise((resolve) => setTimeout(resolve, waittime));
@@ -450,7 +451,7 @@ describe("Update", () => {
         body:
           "@prefix solid: <http://www.w3.org/ns/solid/terms#>.\n" +
           "<#patch> a solid:InsertDeletePatch;\n" +
-          "  solid:deletes { <#something> <#completely> <#different> .}." +
+          "  solid:deletes { <#something> <#completely> <#different> .};\n" +
           "  solid:inserts { <#that> a <#fact> .}.",
       });
     });


### PR DESCRIPTION
This changes the format for multiple lines so that the middle line has a ; on the end instead of a '.';

It goes from 
```
@prefix solid: <http://www.w3.org/ns/solid/terms#>.
<#foo> a solid:InsertDeletePatch;
  solid:deletes { <#hello> <#linked> <#world> .}.
  solid:inserts { <#hello> <#linked> <#world> .}.
``` 

to

```
@prefix solid: <http://www.w3.org/ns/solid/terms#>.
<#patch> a solid:InsertDeletePatch;
  solid:deletes { <#hello> <#linked> <#world> .};
  solid:inserts { <#hello> <#linked> <#world> .}.
```
