### PR TITLE
We need to set `ALICE_WEBID` before running the tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ npm ci
 # To use a different base container set STORAGE_ROOT.
 
 export SERVER_ROOT=https://solid-crud-tests-example-1.solidcommunity.net
+export ALICE_WEBID=https://solid-crud-tests-example-1.solidcommunity.net/profile/card#me
 export USERNAME=solid-crud-tests-example-1
 export PASSWORD=123
 # This curl command is specific to node-solid-server:


### PR DESCRIPTION
If we don't set `ALICE_WEBID` then storage related tests will fail.

Related Issue: https://github.com/nodeSolidServer/node-solid-server/issues/1736